### PR TITLE
4.2 создание каркаса экрана список интересных мест

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -163,7 +163,7 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: MyFirstWidget(),
+      home: SightListScreen(),
       title: "Places",
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'ui/screen/sight_list_screen.dart';
+
 void main() {
   runApp(App());
 }
@@ -22,7 +24,7 @@ class MyApp extends StatelessWidget {
         // is not restarted.
         primarySwatch: Colors.blue,
       ),
-      home: MyFirstStateFulWidget(),
+      home: SightListScreen(),
     );
   }
 }

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class SightListScreen extends StatefulWidget {
+  SightListScreen({Key key}) : super(key: key);
+
+  @override
+  _SightListScreenState createState() => _SightListScreenState();
+}
+
+class _SightListScreenState extends State<SightListScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        child: Text("Scaffold body text"),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Ответьте на вопрос: как сделать так, чтобы Scaffold не реагировал на изменение окна приложения?

Ответ: Если имеется в виду что бы экран SightListScreen не реагировал на изменение ориентации телефона, то удалось найти такой способ.

В методе build виджета SightListScreen можно перечислить все возможные ориентации с помощью 
```
SystemChrome.setPreferredOrientations([
      DeviceOrientation.portraitUp,
      DeviceOrientation.portraitDown
]);
```